### PR TITLE
Use 'completing-read' when Helm is being used

### DIFF
--- a/recent-addresses.el
+++ b/recent-addresses.el
@@ -241,12 +241,7 @@ Unless FORCE is set, an existing list will not be overwritten."
          (candidates (mapcar 'car choices))
          (choice (if ido-mode
                      (ido-completing-read prompt candidates)
-                   (require 'iswitchb)
-                   (with-no-warnings
-                     (let ((iswitchb-make-buflist-hook
-                            (lambda () (setq iswitchb-temp-buflist
-                                             (mapcar 'car choices)))))
-                       (iswitchb-read-buffer prompt))))))
+		   (completing-read prompt candidates))))
     (or (cdr (assoc choice choices))
         choice)))
 


### PR DESCRIPTION
Hello,

This patch makes `recent-addresses.el` Helm-friendly.

Note that `iswitchb` is marked as obsolete since Emacs 24.4, so we might as well remove the else branch.  WDYT?

Thanks for this nice little mode that I've been using for ages!